### PR TITLE
Updates to account for generateName based pods

### DIFF
--- a/app/imageswap-webhook-deploy.py
+++ b/app/imageswap-webhook-deploy.py
@@ -19,16 +19,48 @@ def webhook():
     request_info = request.json
     modified_spec = copy.deepcopy(request_info)
     uid = modified_spec["request"]["uid"]
-    workload = modified_spec["request"]["object"]["metadata"]["name"]
+    workload_metadata = modified_spec["request"]["object"]["metadata"]
+    workload_type = modified_spec["request"]["kind"]["kind"]
     namespace = modified_spec["request"]["namespace"]
+
+    print("")
+    print("##################################################################")
+    print("")
+
+    # Detect if "name" in object metadata
+    # this was added because the request object for pods don't 
+    # include a "name" field in the object metadata. This is because generateName
+    # occurs Server Side post-admission
+    if "name" in workload_metadata:
+        
+        workload = modified_spec["request"]["object"]["metadata"]["name"]
+
+    elif "generateName" in workload_metadata:
+
+        workload = modified_spec["request"]["object"]["metadata"]["generateName"]
+
+    else:
+
+        workload = uid
 
     #pprint(request_info)
 
-    for container_spec in modified_spec["request"]["object"]["spec"]["template"]["spec"]["containers"]:
-        print("INFO - Processing container: {}/{}".format(namespace,workload))
-        swap_image(container_spec)
+    # Change workflow/json path based on K8s object type
+    if workload_type == "Pod":
 
-    print("INFO - Diffing original request to modified request and generating JSONPatch")
+        for container_spec in modified_spec["request"]["object"]["spec"]["containers"]:
+        
+            print("[INFO] - Processing container: {}/{}".format(namespace,workload))
+            swap_image(container_spec)
+
+    else:
+
+        for container_spec in modified_spec["request"]["object"]["spec"]["template"]["spec"]["containers"]:
+
+            print("[INFO] - Processing container: {}/{}".format(namespace,workload))
+            swap_image(container_spec)
+
+    print("[INFO] - Diffing original request to modified request and generating JSONPatch")
 
 
     #print("Original Spec:")
@@ -38,7 +70,7 @@ def webhook():
 
     patch = jsonpatch.JsonPatch.from_diff(request_info["request"]["object"], modified_spec["request"]["object"])
 
-    print("INFO - JSON Patch: {}".format(patch))
+    print("[INFO] - JSON Patch: {}".format(patch))
 
     admission_response = {
         "allowed": True,
@@ -50,7 +82,7 @@ def webhook():
         "response": admission_response
     }
 
-    print("INFO - Sending Response to K8s API Server:")
+    print("[INFO] - Sending Response to K8s API Server:")
     pprint(admissionReview)
     return jsonify(admissionReview)
 
@@ -61,11 +93,11 @@ def swap_image(container_spec):
     name = container_spec["name"]
     image = container_spec["image"]
 
-    print("INFO - Swapping image definition for container spec: {}".format(name))
+    print("[INFO] - Swapping image definition for container spec: {}".format(name))
 
     if image_prefix in image:
 
-        print ("INFO - Internal image definition detected, nothing to do")
+        print ("[INFO] - Internal image definition detected, nothing to do")
 
         admission_response = {
             "allowed": "True"
@@ -79,10 +111,11 @@ def swap_image(container_spec):
         else:
             new_image = image_prefix + re.sub(r'(^.*/)+(.*)',r'/\2',image)
 
-        print ("INFO - External image definition detected: {}".format(image))
-        print ("INFO - External Image updated to Internal image: {}".format(new_image))
+        print ("[INFO] - External image definition detected: {}".format(image))
+        print ("[INFO] - External Image updated to Internal image: {}".format(new_image))
 
         container_spec["image"] = new_image
 
 
 app.run(host='0.0.0.0', port=5000, debug=True, ssl_context=('./ssl/cert.pem', './ssl/key.pem'))
+


### PR DESCRIPTION
This is to add logic to account for variance in workload names. Previously the application made an assumption that the `.object.medata.name` JSON path would exist universally. This is not correct for pods generated by any mechanism than singleton/Statefulset. Pods using the `generateName` field have their name generated server side, post admission review. 