### PR TITLE
Fix unit tests for multi-patch and add dash scenarios

### DIFF
--- a/app/imageswap/imageswap.py
+++ b/app/imageswap/imageswap.py
@@ -160,7 +160,7 @@ def mutate():
         }
 
     app.logger.info("Sending Response to K8s API Server:")
-    app.logger.info(json.dumps(admissionReview))
+    app.logger.info(f"Admission Review: {json.dumps(admissionReview)}")
 
     return jsonify(admissionReview)
 

--- a/app/imageswap/test/test_routes.py
+++ b/app/imageswap/test/test_routes.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
 import json
 import os
 import sys
@@ -122,7 +123,6 @@ class TestRoutes(unittest.TestCase):
 
     # TO-DO (pehnixblue): Need to figure out how to produce consistent results
     # on jsonpath with both init/containers swapped
-    '''
     def test_root_deploy_swap_both(self):
 
         """Method to test root route with deployment request that should swap both the primary container and init-container image definitions"""
@@ -133,15 +133,16 @@ class TestRoutes(unittest.TestCase):
 
             result = self.app.post("/", data=json.dumps(request_object_json), headers={"Content-Type": "application/json"},)
 
+            # Decode base64 encoded patch string into Python List of Dicts. This allows for comparison without the List order impacting assertion
+            result_patch = base64.b64decode(json.loads(result.data)["response"]["patch"]).decode()
+            expected_patch = "W3sib3AiOiAicmVwbGFjZSIsICJwYXRoIjogIi9zcGVjL3RlbXBsYXRlL3NwZWMvaW5pdENvbnRhaW5lcnMvMC9pbWFnZSIsICJ2YWx1ZSI6ICJqbXNlYXJjeS9oZWxsby1rdWJlcm5ldGVzOjEuNSJ9LCB7Im9wIjogInJlcGxhY2UiLCAicGF0aCI6ICIvc3BlYy90ZW1wbGF0ZS9zcGVjL2NvbnRhaW5lcnMvMC9pbWFnZSIsICJ2YWx1ZSI6ICJqbXNlYXJjeS9oZWxsby1rdWJlcm5ldGVzOjEuNSJ9XQ=="
+            expected_patch_decoded = base64.b64decode(expected_patch).decode()
+
             self.assertEqual(result.status_code, 200)
             self.assertEqual(json.loads(result.data)["response"]["allowed"], True)
-            self.assertEqual(
-                json.loads(result.data)["response"]["patch"],
-                "W3sib3AiOiAicmVwbGFjZSIsICJwYXRoIjogIi9zcGVjL3RlbXBsYXRlL3NwZWMvaW5pdENvbnRhaW5lcnMvMC9pbWFnZSIsICJ2YWx1ZSI6ICJqbXNlYXJjeS9oZWxsby1rdWJlcm5ldGVzOjEuNSJ9LCB7Im9wIjogInJlcGxhY2UiLCAicGF0aCI6ICIvc3BlYy90ZW1wbGF0ZS9zcGVjL2NvbnRhaW5lcnMvMC9pbWFnZSIsICJ2YWx1ZSI6ICJqbXNlYXJjeS9oZWxsby1rdWJlcm5ldGVzOjEuNSJ9XQ==",
-            )
+            self.assertCountEqual(result_patch, expected_patch_decoded)
             self.assertEqual(json.loads(result.data)["response"]["patchtype"], "JSONPatch")
             self.assertEqual(json.loads(result.data)["response"]["uid"], "2d213641-c136-49d5-b162-a0d2593639f7")
-    '''
 
     def test_root_pod_noswap(self):
 
@@ -199,7 +200,6 @@ class TestRoutes(unittest.TestCase):
 
     # TO-DO (pehnixblue): Need to figure out how to produce consistent results
     # on jsonpath with both init/containers swapped
-    '''
     def test_root_pod_swap_both(self):
 
         """Method to test root route with pod request that should swap both the primary container and init-container image definitions"""
@@ -210,15 +210,16 @@ class TestRoutes(unittest.TestCase):
 
             result = self.app.post("/", data=json.dumps(request_object_json), headers={"Content-Type": "application/json"},)
 
+            # Decode base64 encoded patch string into Python List of Dicts. This allows for comparison without the List order impacting assertion
+            result_patch = base64.b64decode(json.loads(result.data)["response"]["patch"]).decode()
+            expected_patch = "W3sib3AiOiAicmVwbGFjZSIsICJwYXRoIjogIi9zcGVjL2luaXRDb250YWluZXJzLzAvaW1hZ2UiLCAidmFsdWUiOiAiam1zZWFyY3kvaGVsbG8ta3ViZXJuZXRlczoxLjUifSwgeyJvcCI6ICJyZXBsYWNlIiwgInBhdGgiOiAiL3NwZWMvY29udGFpbmVycy8wL2ltYWdlIiwgInZhbHVlIjogImptc2VhcmN5L2hlbGxvLWt1YmVybmV0ZXM6MS41In1d"
+            expected_patch_decoded = base64.b64decode(expected_patch).decode()
+
             self.assertEqual(result.status_code, 200)
             self.assertEqual(json.loads(result.data)["response"]["allowed"], True)
-            self.assertEqual(
-                json.loads(result.data)["response"]["patch"],
-                "W3sib3AiOiAicmVwbGFjZSIsICJwYXRoIjogIi9zcGVjL2luaXRDb250YWluZXJzLzAvaW1hZ2UiLCAidmFsdWUiOiAiam1zZWFyY3kvaGVsbG8ta3ViZXJuZXRlczoxLjUifSwgeyJvcCI6ICJyZXBsYWNlIiwgInBhdGgiOiAiL3NwZWMvY29udGFpbmVycy8wL2ltYWdlIiwgInZhbHVlIjogImptc2VhcmN5L2hlbGxvLWt1YmVybmV0ZXM6MS41In1d",
-            )
+            self.assertCountEqual(result_patch, expected_patch_decoded)
             self.assertEqual(json.loads(result.data)["response"]["patchtype"], "JSONPatch")
             self.assertEqual(json.loads(result.data)["response"]["uid"], "ffeb2e4a-a440-4f70-90cb-9e960f7471c4")
-    '''
 
     def test_root_pod_swap_noslash(self):
 
@@ -238,6 +239,26 @@ class TestRoutes(unittest.TestCase):
             )
             self.assertEqual(json.loads(result.data)["response"]["patchtype"], "JSONPatch")
             self.assertEqual(json.loads(result.data)["response"]["uid"], "2ca21f3f-a77f-4145-b7ac-bf656a976f46")
+
+    @patch.dict(os.environ, {"IMAGE_PREFIX": "jmsearcy-"})
+    def test_root_pod_swap_dash(self):
+
+        """Method to test root route with pod request that should swap the primary container image definition where the IMAGE_PREFIX ends with a '-'"""
+
+        with open("./testing/deployments/test-deploy02.json") as json_file:
+
+            request_object_json = json.load(json_file)
+
+            result = self.app.post("/", data=json.dumps(request_object_json), headers={"Content-Type": "application/json"},)
+
+            self.assertEqual(result.status_code, 200)
+            self.assertEqual(json.loads(result.data)["response"]["allowed"], True)
+            self.assertEqual(
+                json.loads(result.data)["response"]["patch"],
+                "W3sib3AiOiAicmVwbGFjZSIsICJwYXRoIjogIi9zcGVjL3RlbXBsYXRlL3NwZWMvY29udGFpbmVycy8wL2ltYWdlIiwgInZhbHVlIjogImptc2VhcmN5LXBhdWxib3V3ZXIvaGVsbG8ta3ViZXJuZXRlczoxLjUifV0=",
+            )
+            self.assertEqual(json.loads(result.data)["response"]["patchtype"], "JSONPatch")
+            self.assertEqual(json.loads(result.data)["response"]["uid"], "29df64b9-da70-4044-ac07-4fcff7c3eb5c")
 
     def test_root_pod_swap_generatename(self):
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/phenixblue/imageswap-webhook/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added and/or ran the appropriate tests for your PR
4. If the PR is unfinished, please mark it as "[WIP]"
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind bug

/kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind feature

**What this PR does / why we need it**:

- Fixes previous issues with multi-patch scenarios and ordering issues with assertions in unit tests
- Adds unit test coverage for the scenario where the IMAGE_PREFIX env var ends with a `-`
- Simple string interpolation fix for some logging in imageswap.py

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #16 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required"
-->

```release-note

```

**Additional documentation e.g., usage docs, etc.**:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```