### PR TITLE
Fix image build repo filter

### DIFF
--- a/.github/workflows/ci-image-build.yaml
+++ b/.github/workflows/ci-image-build.yaml
@@ -43,7 +43,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build and push imageswap-init image to DockerHub
-        if: github.repository == 'phenixblue/imageswap'
+        if: github.repository == 'phenixblue/imageswap-webhook'
         timeout-minutes: 30
         uses: docker/build-push-action@v2
         with:
@@ -90,7 +90,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build and push imageswap image to DockerHub
-        if: github.repository == 'phenixblue/imageswap'
+        if: github.repository == 'phenixblue/imageswap-webhook'
         timeout-minutes: 30
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/phenixblue/imageswap-webhook/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added and/or ran the appropriate tests for your PR
4. If the PR is unfinished, please mark it as "[WIP]"
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind bug

/kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind feature
> /kind release

**What this PR does / why we need it**:

This fixes an issue with the GitHub Action filter for the Image Build workflow. It was incorrectly filtering the image build for the `phenixblue/imageswap` repo instead of `pheniblue/imageswap-webhook` repo. 

This fixes that so the image build should now run correctly.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

NA

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required"
-->

```release-note
NONE
```

**Additional documentation e.g., usage docs, etc.**:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```