### PR TITLE
Add fix for dotted tag on library image

### DIFF
--- a/app/imageswap/imageswap.py
+++ b/app/imageswap/imageswap.py
@@ -240,7 +240,7 @@ def swap_image(container_spec):
     library_image = False
 
     # Check if first section is a Registry URL
-    if "." in image_split[0]:
+    if "." in image_split[0] and image_split[1] != "" and image_split[2] != "":
         image_registry = image_split[0]
     else:
         # Set docker.io if no registry is detected

--- a/app/imageswap/test/test_image_map_configs.py
+++ b/app/imageswap/test/test_image_map_configs.py
@@ -198,6 +198,22 @@ class GoodConfig(unittest.TestCase):
         self.assertTrue(result)
         self.assertEqual(container_spec["image"], expected_image)
 
+    def test_map_config_with_library_image_with_dotted_tag(self):
+
+        """Method to test Map File config (map with library registry and a tag that contains a ".")"""
+
+        imageswap.imageswap_maps_file = "./testing/map_files/map_file_library_image.conf"
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "rabbitmq:3.8.18-management"
+
+        expected_image = "harbor.example.com/library/rabbitmq:3.8.18-management"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/app/imageswap/test/test_image_patterns.py
+++ b/app/imageswap/test/test_image_patterns.py
@@ -209,6 +209,20 @@ class ImageFormats(unittest.TestCase):
         self.assertTrue(result)
         self.assertEqual(container_spec["image"], expected_image)
 
+    def test_image_format_library_image_with_dotted_tag(self):
+
+        """Method to test MAP based swap (library image with tag that contains a ".": \"rabbitmq:3.8.18-management\")"""
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "rabbitmq:3.8.18-management"
+
+        expected_image = "my.example.com/mirror-docker.io/rabbitmq:3.8.18-management"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/phenixblue/imageswap-webhook/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added and/or ran the appropriate tests for your PR
4. If the PR is unfinished, please mark it as "[WIP]"
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>

/kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind feature
> /kind release

**What this PR does / why we need it**:

This PR fixes an issue in the swap logic where image definitions that contained a library image + a tag that contains one or more `.`'s would be treated as a registry + a blank image name.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #46 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required"
-->

```release-note
Adjust swap logic to appropriately handle library images that have a tag that contains one or more `.`'s
```

**Additional documentation e.g., usage docs, etc.**:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs
NONE
```