### PR TITLE
Add logic to handle `:<port>` in key or value for swap map entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,10 +104,25 @@ This release fixes a bug in the image swap logic related to a scenario where a l
 
 More info can be found in this issue: #46
 
-### Enahncements
+### Enhancements
 
 - Add fix for dotted tag on library image (#47)
 
 ### Acknowledgements
 
 - Thanks to @adavenpo for bringing this to our attention
+
+## 1.4.3
+
+This release moves to using a new syntax (`::`) to separate the key and value portions of a map definition in the maps file. Backwards compatibility is maintained for the existing `:` syntax, but this has been deprecated and should not be used. Please update any existing map configurations to use the new syntax.
+
+This release also adds additional validation to catch errors associated with specifying a registry in a map definition key that includes the `:<port_number>` syntax. Previously this would result in an error and a stack trace. This is now handled gracefully and the new map separator syntax should allow for registries to include ports going forward.
+
+### Enhancements
+
+- Add support for new map definition deparator syntax (#50)
+
+### Acknowledgements
+
+- Thanks to @sblair-metrostar for bringing this to our attention
+

--- a/README.md
+++ b/README.md
@@ -125,27 +125,31 @@ MAPS Mode enables a high degree of flexibility for the ImageSwap Webhook.
 
 In MAPS mode, the webhook reads from a `map file` that defines one or more mappings (key/value pairs) for imageswap logic. With the `map file` configuration, swap logic for multiple registries and patterns can be configured. In contrast, the LEGACY mode only allowed for a single `IMAGE_PREFIX` to be defined for image swaps.
 
-A `map file` is composed of key/value pairs separated by a `:` and looks like this:
+A `map file` is composed of key/value pairs separated by a `::` and looks like this:
 
 ```
-default:default.example.com
-docker.io:my.example.com/mirror-
-quay.io:quay.example3.com
-gitlab.com:registry.example.com/gitlab
-#gcr.io: # This is a comment 
-cool.io:
-registry.internal.twr.io:registry.example.com
-harbor.geo.pks.twr.io:harbor2.com ###### This is a comment with many symbols
-noswap_wildcards:twr.io, walrus.io
+default::default.example.com
+docker.io::my.example.com/mirror-
+quay.io::quay.example3.com
+gitlab.com::registry.example.com/gitlab
+#gcr.io:: # This is a comment 
+cool.io::
+registry.internal.twr.io::registry.example.com
+harbor.geo.pks.twr.io::harbor2.com ###### This is a comment with many symbols
+noswap_wildcards::twr.io, walrus.io
 ```
 
 NOTE: Lines in the `map file` that are commented out with a leading `#` are ignored. Trailing comments following a map definition are also ignored.
+
+NOTE: Previous versions of ImageSwap used a single `:` syntax to separate the key and value portions of a map definition. This syntax is deprecated as of v1.4.3 and will be removed in future versions. Please be sure to update any existing map file configurations to use the new syntax (ie. `::`).
+
+NOTE: Prior to v1.4.3 any use of a registry that includes a port for the key of a map definition will result in errors.
 
 The only mapping that is required in the `map_file` is the `default` map. The `default` map alone provides similar functionality to the `LEGACY` mode.
 
 A map definition that includes a `key` only can be used to disable image swapping for that particular registry.
 
-A map file can also include a special `noswap_wildcards` mapping that disables swapping based on greedy pattern matching. Don't actually include an `*` in this section. A value of `example` is essentialy equivalent to `*example*`. [See examples below for more detail](#example-maps-configs)
+A map file can also include a special `noswap_wildcards` mapping that disables swapping based on greedy pattern matching. Don't actually include an `*` in this section. A value of `example` is essentially equivalent to `*example*`. [See examples below for more detail](#example-maps-configs)
 
 By adding additional mappings to the `map file`, you can have much finer granularity to control swapping logic per registry.
 
@@ -156,21 +160,21 @@ By adding additional mappings to the `map file`, you can have much finer granula
 
   ```
   default:
-  gcr.io:harbor.internal.example.com
+  gcr.io::harbor.internal.example.com
   ```
 
 - Enable image swapping for all registries except `gcr.io`
 
   ```
-  default: harbor.internal.example.com
-  gcr.io:
+  default::harbor.internal.example.com
+  gcr.io::
   ```
 
 - Imitate LEGACY functionality as close as possible
 
   ```
-  default:harbor.internal.example.com
-  noswap_wildcards:harbor.internal.example.com
+  default::harbor.internal.example.com
+  noswap_wildcards::harbor.internal.example.com
   ```
 
   With this, all images will be swapped except those that already match the `harbor.internal.example.com` pattern
@@ -178,8 +182,8 @@ By adding additional mappings to the `map file`, you can have much finer granula
 - Enable swapping for all registries except those that match the `example.com` pattern
 
   ```
-  default:harbor.internal.example.com
-  noswap_wildcards:example.com
+  default::harbor.internal.example.com
+  noswap_wildcards::example.com
   ```
 
   With this, images that have any part of the registry that matches `example.com` will skip the swap logic
@@ -208,9 +212,9 @@ By adding additional mappings to the `map file`, you can have much finer granula
   [Official Docker documentation on image naming](https://docs.docker.com/registry/introduction/#understanding-image-naming)
 
   ```
-  default:
-  docker.io:
-  docker.io/library:harbor.example.com/library
+  default::
+  docker.io::
+  docker.io/library::harbor.example.com/library
   ```
 
   This map uses a special syntax of adding `/library` to a registry for the key in map file.

--- a/app/imageswap/imageswap.py
+++ b/app/imageswap/imageswap.py
@@ -219,12 +219,16 @@ def build_swap_map(map_file):
                 (key, val) = line.split("::")
             # Check for old style separator (":") and verify the map splits correctly
             elif ":" in line and len(line.split(":")) == 2:
-                app.logger.warning(f"Map defined with \":\" as separator. This syntax is now deprecated. Please use \"::\" to separate the key and value in the map file: {line}")
+                app.logger.warning(
+                    f'Map defined with ":" as separator. This syntax is now deprecated. Please use "::" to separate the key and value in the map file: {line}'
+                )
                 (key, val) = line.split(":")
             else:
                 # Check if map key contains a ":port" and that the new style separator ("::") is not used
                 if line.count(":") > 1 and "::" not in line:
-                    app.logger.warning(f"Invalid map is specified. A port in the map key or value requires using \"::\" as the separator. Skipping map for line: {line}")
+                    app.logger.warning(
+                        f'Invalid map is specified. A port in the map key or value requires using "::" as the separator. Skipping map for line: {line}'
+                    )
                 # Warn for any other invalid map syntax
                 else:
                     app.logger.warning(f"Invalid map is specified. Incorrect syntax for map definition. Skipping map for line: {line}")

--- a/app/imageswap/test/test_image_map_configs.py
+++ b/app/imageswap/test/test_image_map_configs.py
@@ -54,6 +54,22 @@ class BadConfig(unittest.TestCase):
         self.assertFalse(result)
         self.assertEqual(container_spec["image"], expected_image)
 
+    def test_map_config_with_port_in_key_and_old_separator(self):
+
+        """Method to test Map File config (map with port in key and old separator ":")"""
+
+        imageswap.imageswap_maps_file = "./testing/map_files/map_file.conf"
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "registry2.bar.com:8443/jmsearcy/twrtools:latest"
+
+        expected_image = "default.example.com/jmsearcy/twrtools:latest"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
 
 @patch("imageswap.imageswap_mode", "MAPS")
 @patch("imageswap.imageswap_maps_file", "./testing/map_files/map_file.conf")
@@ -213,6 +229,53 @@ class GoodConfig(unittest.TestCase):
 
         self.assertTrue(result)
         self.assertEqual(container_spec["image"], expected_image)
+
+    def test_map_config_with_port_in_key(self):
+
+        """Method to test Map File config (map with port in key)"""
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "registry.waldo.com:8443/jmsearcy/twrtools:latest"
+
+        expected_image = "registry.garply.com/jmsearcy/twrtools:latest"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
+    def test_map_config_with_port_in_value(self):
+
+        """Method to test Map File config (map with port in value)"""
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "registry.foo.com/jmsearcy/twrtools:latest"
+
+        expected_image = "localhost:30003/foo/jmsearcy/twrtools:latest"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
+    def test_map_config_with_port_in_key_and_value(self):
+
+        """Method to test Map File config (map with port in key & value)"""
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "registry.bar.com:8443/jmsearcy/twrtools:latest"
+
+        expected_image = "registry.baz.com:30003/bar/jmsearcy/twrtools:latest"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
+#registry.waldo.com:8443:registry.garply.com # Swap map key that includes a port
+#registry.foo.com:localhost:30003/foo # Swap map value that includes a port
+#registry.bar.com:8443:registry.baz.com:30003/bar # Swap map key & value that include a port
+#registry2.bar.com:8443:registry2.baz.com:30003/bar # Bad config without "::" separator
 
 
 if __name__ == "__main__":

--- a/app/imageswap/test/test_image_map_configs.py
+++ b/app/imageswap/test/test_image_map_configs.py
@@ -288,11 +288,6 @@ class GoodConfig(unittest.TestCase):
         self.assertTrue(result)
         self.assertEqual(container_spec["image"], expected_image)
 
-#registry.waldo.com:8443:registry.garply.com # Swap map key that includes a port
-#registry.foo.com:localhost:30003/foo # Swap map value that includes a port
-#registry.bar.com:8443:registry.baz.com:30003/bar # Swap map key & value that include a port
-#registry2.bar.com:8443:registry2.baz.com:30003/bar # Bad config without "::" separator
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/app/imageswap/test/test_image_map_configs.py
+++ b/app/imageswap/test/test_image_map_configs.py
@@ -62,7 +62,23 @@ class BadConfig(unittest.TestCase):
 
         container_spec = {}
         container_spec["name"] = "test-container"
-        container_spec["image"] = "registry2.bar.com:8443/jmsearcy/twrtools:latest"
+        container_spec["image"] = "registry2.bar.com/jmsearcy/twrtools:latest"
+
+        expected_image = "default.example.com/jmsearcy/twrtools:latest"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
+    def test_map_config_with_port_in_value_and_old_separator(self):
+
+        """Method to test Map File config (map with port in value and old separator ":")"""
+
+        imageswap.imageswap_maps_file = "./testing/map_files/map_file.conf"
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "registry3.bar.com:8443/jmsearcy/twrtools:latest"
 
         expected_image = "default.example.com/jmsearcy/twrtools:latest"
         result = imageswap.swap_image(container_spec)

--- a/testing/map_files/map_file.conf
+++ b/testing/map_files/map_file.conf
@@ -11,7 +11,7 @@ harbor.geo.pks.twr.io:harbor2.com ###### This is a comment with many symbols
 registry.waldo.com:8443::registry.garply.com # Swap map key that includes a port
 registry.foo.com::localhost:30003/foo # Swap map value that includes a port
 registry.bar.com:8443::registry.baz.com:30003/bar # Swap map key & value that include a port
-registry2.bar.com:registry2.baz.com:30003/bar # Bad config without "::" separator
-registry3.bar.com:8443:registry.internal.baz.com:30003/bar # Bad config without "::" separator
+registry2.bar.com:registry2.baz.com:30003/bar # Bad config (port in value) without "::" separator
+registry3.bar.com:8443:registry.internal.baz.com:30003/bar # Bad config (port in key and value) without "::" separator
 registry4.bar.com;registry.internal.baz.com/bar # Bad config with invalid separator
 noswap_wildcards:twr.io, walrus.io

--- a/testing/map_files/map_file.conf
+++ b/testing/map_files/map_file.conf
@@ -11,5 +11,7 @@ harbor.geo.pks.twr.io:harbor2.com ###### This is a comment with many symbols
 registry.waldo.com:8443::registry.garply.com # Swap map key that includes a port
 registry.foo.com::localhost:30003/foo # Swap map value that includes a port
 registry.bar.com:8443::registry.baz.com:30003/bar # Swap map key & value that include a port
-registry2.bar.com:8443:registry2.baz.com:30003/bar # Bad config without "::" separator
+registry2.bar.com:registry2.baz.com:30003/bar # Bad config without "::" separator
+registry3.bar.com:8443:registry.internal.baz.com:30003/bar # Bad config without "::" separator
+registry4.bar.com;registry.internal.baz.com/bar # Bad config with invalid separator
 noswap_wildcards:twr.io, walrus.io

--- a/testing/map_files/map_file.conf
+++ b/testing/map_files/map_file.conf
@@ -8,4 +8,8 @@ gitlab.com:registry.example.com/gitlab
 cool.io:
 registry.internal.twr.io:registry.example.com
 harbor.geo.pks.twr.io:harbor2.com ###### This is a comment with many symbols
+registry.waldo.com:8443::registry.garply.com # Swap map key that includes a port
+registry.foo.com::localhost:30003/foo # Swap map value that includes a port
+registry.bar.com:8443::registry.baz.com:30003/bar # Swap map key & value that include a port
+registry2.bar.com:8443:registry2.baz.com:30003/bar # Bad config without "::" separator
 noswap_wildcards:twr.io, walrus.io


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/phenixblue/imageswap-webhook/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added and/or ran the appropriate tests for your PR
4. If the PR is unfinished, please mark it as "[WIP]"
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>

 /kind bug

> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind feature
> /kind release

**What this PR does / why we need it**:

This PR adds additional logic to handle `:<port>` style registry syntax for the key or value portions of a map definition.

Example:

```
registry.waldo.com:8443::registry.garply.com # Swap map key that includes a port
registry.foo.com::localhost:30003/foo # Swap map value that includes a port
registry.bar.com:8443::registry.baz.com:30003/bar # Swap map key & value that include a port
```

This adds a new separator type for map definitions: `::` instead of `:`

Going forward the `::` syntax will be the default, but for now the existing `:` will work for any map definitions that don't include a port in the key or value.

Additional logic has also been added to handle the case where a map definition includes a port in the key or value with/without the new separator. 

Warning messages will be logged for maps using the old style separator or when a port is specified with the incorrect syntax.



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #49 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required"
-->

```release-note
- The existing separator syntax for maps (ie `:`) has been deprecated. A new separator syntax has been added for map definitions. Please use `::` instead of `:` from now on. 
- Logic has been added to filter out lines of the map file with incorrect syntax. While this shouldn't interfere with backwards compatibility, not all possible combinations of characters have been tested. Check the logs of the ImageSwap pods if you experience issues and open an issue if necessary.
```

**Additional documentation e.g., usage docs, etc.**:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```