### PR TITLE
Fixes #51 add mapping mode "EXACT"

### DIFF
--- a/app/imageswap/imageswap.py
+++ b/app/imageswap/imageswap.py
@@ -270,7 +270,16 @@ def swap_image(container_spec):
     image_registry_key = image_registry
 
     # Check the imageswap mode
-    if imageswap_mode.lower() == "maps":
+    if imageswap_mode.lower() == "exact":
+        app.logger.info('ImageSwap Webhook running in "EXACT" mode')
+        swap_maps = build_swap_map(imageswap_maps_file)
+        app.logger.debug(f"Swap Maps:\n{swap_maps}")
+        if image not in swap_maps:
+            return False
+        new_image = swap_maps[image]
+
+    
+    elif imageswap_mode.lower() == "maps":
 
         app.logger.info('ImageSwap Webhook running in "MAPS" mode')
 

--- a/app/imageswap/test/test_exact_mapping.py
+++ b/app/imageswap/test/test_exact_mapping.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+
+# Copyright 2020 The WebRoot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.append("./app/imageswap")
+import imageswap
+
+###########################################################################
+# Test image tag mapping scenarios ########################################
+###########################################################################
+
+
+@patch("imageswap.imageswap_mode", "EXACT")
+@patch("imageswap.imageswap_maps_file", "./testing/map_files/map_file.conf")
+class ExactMapping(unittest.TestCase):
+    def setUp(self):
+
+        self.app = imageswap.app.test_client()
+        self.app.testing = True
+        imageswap.app.logger.setLevel("DEBUG")
+
+    def tearDown(self):
+
+        pass
+
+    def test_map_exact_helloworld(self):
+
+        """Method to test Map File config (default swap map has no value)"""
+
+        imageswap.imageswap_maps_file = "./testing/map_files/map_file_exact.conf"
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "hello-world"
+
+        expected_image = "myownrepo.example.com/base/public-image-cache:hello-world"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
+
+    def test_map_exact_ubuntu(self):
+
+        """Method to test Map File config (default swap map has no value)"""
+
+        imageswap.imageswap_maps_file = "./testing/map_files/map_file_exact.conf"
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "ubutun:18.04"
+
+        expected_image = "myownrepo.example.com/base/public-image-cache:ubuntu_18.04"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
+
+    def test_map_mysqlserver(self):
+
+        """Method to test Map File config (default swap map has no value)"""
+
+        imageswap.imageswap_maps_file = "./testing/map_files/map_file_exact.conf"
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "mysql/mysql-server"
+
+        expected_image = "myownrepo.example.com/base/public-image-cache:mysql_mysql-server"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
+
+    def test_map_mysqlserver56(self):
+
+        """Method to test Map File config (default swap map has no value)"""
+
+        imageswap.imageswap_maps_file = "./testing/map_files/map_file_exact.conf"
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "mysql/mysql-server:5.6"
+
+        expected_image = "myownrepo.example.com/base/public-image-cache:mysql_mysql-server_5.6"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
+
+    def test_map_exact_nvcr(self):
+
+        """Method to test Map File config (default swap map has no value)"""
+
+        imageswap.imageswap_maps_file = "./testing/map_files/map_file_exact.conf"
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "nvcr.io/nvidia:k8s-device-plugin_v0.9.0"
+
+        expected_image = "myownrepo.example.com/base/private-image-cache:nvcr.io_nvidia_k8s-device-plugin_v0.9.0"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/testing/map_files/map_file_exact.conf
+++ b/testing/map_files/map_file_exact.conf
@@ -1,0 +1,7 @@
+# The contents of this file is linked to Python unittest assertions and should 
+# not be changed without consideration for updating the related tests.
+hello-world::myownrepo.example.com/base/public-image-cache:hello-world
+ubutun:18.04::myownrepo.example.com/base/public-image-cache:ubuntu_18.04
+mysql/mysql-server::myownrepo.example.com/base/public-image-cache:mysql_mysql-server
+mysql/mysql-server:5.6::myownrepo.example.com/base/public-image-cache:mysql_mysql-server_5.6
+nvcr.io/nvidia:k8s-device-plugin_v0.9.0::myownrepo.example.com/base/private-image-cache:nvcr.io_nvidia_k8s-device-plugin_v0.9.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/phenixblue/imageswap-webhook/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added and/or ran the appropriate tests for your PR
4. If the PR is unfinished, please mark it as "[WIP]"
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

See ISSUE #51 

**Which issue(s) this PR fixes**:

Fixes #51 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Support for new mapping-mode "EXACT" was added.
The enhancement is backward compatible, so the "MAPS" and "LEGACY" mapping modes work as before.
```

**Additional documentation e.g., usage docs, etc.**:

```docs
To activate the new mapping mode the environment variable IMAGESWAP_MODE has to be set to "EXACT".
In this mode, the mapping configuration is handled simply by matching the full docker image name against the left side 
of the mapping. If the docker image name contains an image tag, the new seperator syntax "::" has to be used 
in the mapping file. E.g.:

    mysql/mysql-server:5.6::myownrepo.example.com/base/public-image-cache:mysql_mysql-server_5.6

```