### PR TITLE
Add new Feture "Exact Image Mapping"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 **/__pycache__
 .coverage
 .vscode
+/.project
+/.pydevproject

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ cool.io::
 registry.internal.twr.io::registry.example.com
 harbor.geo.pks.twr.io::harbor2.com ###### This is a comment with many symbols
 noswap_wildcards::twr.io, walrus.io
+# exact image mapping (full docker image name)
+[EXACT]ghcr.io/fantasy/coolstuff:v1.0::my-local-registry.com/patched-coolstuff:latest
 ```
 
 NOTE: Lines in the `map file` that are commented out with a leading `#` are ignored. Trailing comments following a map definition are also ignored.
@@ -153,7 +155,13 @@ A map file can also include a special `noswap_wildcards` mapping that disables s
 
 By adding additional mappings to the `map file`, you can have much finer granularity to control swapping logic per registry.
 
+#### Exact image mapping
 
+By using the prefix `[EXACT]` entries of the mapping file can be marked to be handled as exact image name matching. 
+Those entries `[EXACT]<source-imafe>::<target-image>` will be matched exactly against the <source-image> name (no logic about `docker.io` host or `:latest` image tag) and replaced with the <target-image> name.
+
+Exact image matches are handled before all other mapping rules.
+ 
 #### Example MAPS Configs
 
 - Disable image swapping for all registries EXCEPT `gcr.io`

--- a/README.md
+++ b/README.md
@@ -157,8 +157,15 @@ By adding additional mappings to the `map file`, you can have much finer granula
 
 #### Exact Image Mapping
 
-By using the prefix `[EXACT]` entries of the mapping file can be marked to be handled as exact image name matching. 
-Those entries `[EXACT]<source-image>::<target-image>` will be matched exactly against the `<source-image>` name (no logic about `docker.io/` host or `:latest` image tag) and replaced with the `<target-image>` name.
+Map definitions can become explicit mappings for individual images by using the `[EXACT]` prefix.
+
+Example:
+
+```
+[EXACT]<source-image>::<target-image>
+```
+
+`Exact` maps will be matched exactly against the `<source-image>` name and replaced with the `<target-image>` name. No inferences for registry (ie. `docker.io/`), or tag (ie. `:latest`) will be inferred for `Exact` maps.
 
 Exact image matches are handled before all other mapping rules.
  

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ By adding additional mappings to the `map file`, you can have much finer granula
 #### Exact image mapping
 
 By using the prefix `[EXACT]` entries of the mapping file can be marked to be handled as exact image name matching. 
-Those entries `[EXACT]<source-imafe>::<target-image>` will be matched exactly against the <source-image> name (no logic about `docker.io` host or `:latest` image tag) and replaced with the <target-image> name.
+Those entries `[EXACT]<source-imafe>::<target-image>` will be matched exactly against the `<source-image>` name (no logic about `docker.io/` host or `:latest` image tag) and replaced with the `<target-image>` name.
 
 Exact image matches are handled before all other mapping rules.
  

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ By adding additional mappings to the `map file`, you can have much finer granula
 #### Exact image mapping
 
 By using the prefix `[EXACT]` entries of the mapping file can be marked to be handled as exact image name matching. 
-Those entries `[EXACT]<source-imafe>::<target-image>` will be matched exactly against the `<source-image>` name (no logic about `docker.io/` host or `:latest` image tag) and replaced with the `<target-image>` name.
+Those entries `[EXACT]<source-image>::<target-image>` will be matched exactly against the `<source-image>` name (no logic about `docker.io/` host or `:latest` image tag) and replaced with the `<target-image>` name.
 
 Exact image matches are handled before all other mapping rules.
  

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ A map file can also include a special `noswap_wildcards` mapping that disables s
 
 By adding additional mappings to the `map file`, you can have much finer granularity to control swapping logic per registry.
 
-#### Exact image mapping
+#### Exact Image Mapping
 
 By using the prefix `[EXACT]` entries of the mapping file can be marked to be handled as exact image name matching. 
 Those entries `[EXACT]<source-image>::<target-image>` will be matched exactly against the `<source-image>` name (no logic about `docker.io/` host or `:latest` image tag) and replaced with the `<target-image>` name.

--- a/app/imageswap/imageswap.py
+++ b/app/imageswap/imageswap.py
@@ -67,6 +67,8 @@ def mutate():
     workload_metadata = modified_spec["request"]["object"]["metadata"]
     workload_type = modified_spec["request"]["kind"]["kind"]
     namespace = modified_spec["request"]["namespace"]
+    # flag, whether there was at least one change, so that a patch has to be returned
+    needs_patch = False
 
     app.logger.info("##################################################################")
 
@@ -88,9 +90,6 @@ def mutate():
 
     app.logger.debug(json.dumps(request.json))
 
-    # flag, whether there were any changes for at lease one image.
-    needs_patch = False
-
     # Skip patching if disable label is found and set to "disable"
     if (
         "labels" in workload_metadata
@@ -99,6 +98,7 @@ def mutate():
     ):
 
         app.logger.info(f'Disable label "{imageswap_disable_label}=disabled" detected for "{workload}" {workload_type}", skipping image swap.')
+        needs_patch = False
 
     else:
 

--- a/app/imageswap/imageswap.py
+++ b/app/imageswap/imageswap.py
@@ -282,7 +282,7 @@ def swap_image(container_spec):
 
         app.logger.info('ImageSwap Webhook running in "MAPS" mode')
 
-        (exact_maps, swap_maps)= build_swap_map(imageswap_maps_file)
+        (exact_maps, swap_maps) = build_swap_map(imageswap_maps_file)
 
         app.logger.debug(f"Swap Maps:\n{swap_maps}")
         app.logger.debug(f"Exact Maps:\n{exact_maps}")
@@ -296,35 +296,35 @@ def swap_image(container_spec):
                 image_registry_noport = image_registry.partition(":")[0]
             else:
                 image_registry_noport = image_registry
-    
+
             if image_registry not in swap_maps and image_registry_noport in swap_maps:
                 image_registry_key = image_registry_noport
-    
+
             # Verify the default map exists or skip swap
             if imageswap_maps_default_key not in swap_maps:
                 app.logger.warning(f'You don\'t have a "{imageswap_maps_default_key}" entry in your ImageSwap Map config, skipping swap')
                 return False
-    
+
             # Check for noswap wildcards in map file
             if imageswap_maps_wildcard_key in swap_maps and swap_maps[imageswap_maps_wildcard_key] != "":
                 wildcard_maps = str(swap_maps[imageswap_maps_wildcard_key]).split(",")
-    
+
             # Check if registry or registry+library has a map specified
             if image_registry_key in swap_maps or image_registry_key + "/library" in swap_maps:
-    
+
                 # Check for Library image (ie. empty strings for index 1 an 2 in image_split)
                 if image_split[1] == "" and image_split[2] == "":
                     library_image = True
                     app.logger.debug("Image is a Library image")
                 else:
                     app.logger.debug("Image is not a Library image")
-    
+
                 if library_image and image_registry_key + "/library" in swap_maps:
-    
+
                     image_registry_key = image_registry_key + "/library"
                     app.logger.info(f"Library Image detected and matching Map found: {image_registry_key}")
                     app.logger.debug("More info on Library Image: https://docs.docker.com/registry/introduction/#understanding-image-naming")
-    
+
                 # If the swap map has no value, swapping should be skipped
                 if swap_maps[image_registry_key] == "":
                     app.logger.debug(f'Swap map for "{image_registry_key}" has no value assigned, skipping swap')
@@ -341,9 +341,9 @@ def swap_image(container_spec):
                 # For everything else
                 else:
                     new_image = swap_maps[image_registry_key] + "/" + image
-    
+
                 app.logger.debug(f'Swap Map = "{image_registry_key}" : "{swap_maps[image_registry_key]}"')
-    
+
             # Check if any of the noswap wildcard patterns from the swap map exist within the original image
             elif len(wildcard_maps) > 0 and any(noswap in image for noswap in wildcard_maps):
                 app.logger.debug(f"Image matches a configured noswap_wildcard pattern, skipping swap")
@@ -351,10 +351,10 @@ def swap_image(container_spec):
                 return False
             # Using Default image swap map
             else:
-    
+
                 app.logger.debug(f'No Swap map for "{image_registry_key}" detected, using default map')
                 app.logger.debug(f'Swap Map = "default" : "{swap_maps[imageswap_maps_default_key]}"')
-    
+
                 if swap_maps[imageswap_maps_default_key] == "":
                     app.logger.debug(f"Default map has no value assigned, skipping swap")
                     return False

--- a/app/imageswap/imageswap.py
+++ b/app/imageswap/imageswap.py
@@ -413,8 +413,11 @@ def main():
     app.logger.info("ImageSwap v1.4.2patched Startup")
 
     app.run(
-        #host="0.0.0.0", port=5000, debug=False, threaded=True, ssl_context=("./tls/cert.pem", "./tls/key.pem",),
-        host="0.0.0.0", port=5000, debug=False, threaded=True,
+        # host="0.0.0.0", port=5000, debug=False, threaded=True, ssl_context=("./tls/cert.pem", "./tls/key.pem",),
+        host="0.0.0.0",
+        port=5000,
+        debug=False,
+        threaded=True,
     )
 
 

--- a/app/imageswap/imageswap.py
+++ b/app/imageswap/imageswap.py
@@ -413,11 +413,7 @@ def main():
     app.logger.info("ImageSwap v1.4.2patched Startup")
 
     app.run(
-        # host="0.0.0.0", port=5000, debug=False, threaded=True, ssl_context=("./tls/cert.pem", "./tls/key.pem",),
-        host="0.0.0.0",
-        port=5000,
-        debug=False,
-        threaded=True,
+        host="0.0.0.0", port=5000, debug=False, threaded=True, ssl_context=("./tls/cert.pem", "./tls/key.pem",),
     )
 
 

--- a/app/imageswap/imageswap.py
+++ b/app/imageswap/imageswap.py
@@ -67,7 +67,6 @@ def mutate():
     workload_metadata = modified_spec["request"]["object"]["metadata"]
     workload_type = modified_spec["request"]["kind"]["kind"]
     namespace = modified_spec["request"]["namespace"]
-    needs_patch = False
 
     app.logger.info("##################################################################")
 
@@ -89,6 +88,9 @@ def mutate():
 
     app.logger.debug(json.dumps(request.json))
 
+    # flag, whether there were any changes for at lease one image.
+    needs_patch = False
+
     # Skip patching if disable label is found and set to "disable"
     if (
         "labels" in workload_metadata
@@ -97,7 +99,6 @@ def mutate():
     ):
 
         app.logger.info(f'Disable label "{imageswap_disable_label}=disabled" detected for "{workload}" {workload_type}", skipping image swap.')
-        needs_patch = False
 
     else:
 
@@ -107,28 +108,28 @@ def mutate():
             for container_spec in modified_spec["request"]["object"]["spec"]["containers"]:
 
                 app.logger.info(f"Processing container: {namespace}/{workload}")
-                needs_patch = swap_image(container_spec)
+                needs_patch = swap_image(container_spec) or needs_patch
 
             if "initContainers" in modified_spec["request"]["object"]["spec"]:
 
                 for init_container_spec in modified_spec["request"]["object"]["spec"]["initContainers"]:
 
                     app.logger.info(f"Processing init-container: {namespace}/{workload}")
-                    needs_patch = swap_image(init_container_spec)
+                    needs_patch = swap_image(init_container_spec) or needs_patch
 
         else:
 
             for container_spec in modified_spec["request"]["object"]["spec"]["template"]["spec"]["containers"]:
 
                 app.logger.info(f"Processing container: {namespace}/{workload}")
-                needs_patch = swap_image(container_spec)
+                needs_patch = swap_image(container_spec) or needs_patch
 
             if "initContainers" in modified_spec["request"]["object"]["spec"]["template"]["spec"]:
 
                 for init_container_spec in modified_spec["request"]["object"]["spec"]["template"]["spec"]["initContainers"]:
 
                     app.logger.info(f"Processing init-container: {namespace}/{workload}")
-                    needs_patch = swap_image(init_container_spec)
+                    needs_patch = swap_image(init_container_spec) or needs_patch
 
     if needs_patch:
 
@@ -409,10 +410,11 @@ def swap_image(container_spec):
 
 def main():
 
-    app.logger.info("ImageSwap v1.4.2 Startup")
+    app.logger.info("ImageSwap v1.4.2patched Startup")
 
     app.run(
-        host="0.0.0.0", port=5000, debug=False, threaded=True, ssl_context=("./tls/cert.pem", "./tls/key.pem",),
+        #host="0.0.0.0", port=5000, debug=False, threaded=True, ssl_context=("./tls/cert.pem", "./tls/key.pem",),
+        host="0.0.0.0", port=5000, debug=False, threaded=True,
     )
 
 

--- a/app/imageswap/imageswap.py
+++ b/app/imageswap/imageswap.py
@@ -410,7 +410,7 @@ def swap_image(container_spec):
 
 def main():
 
-    app.logger.info("ImageSwap v1.4.2patched Startup")
+    app.logger.info("ImageSwap v1.4.2 Startup")
 
     app.run(
         host="0.0.0.0", port=5000, debug=False, threaded=True, ssl_context=("./tls/cert.pem", "./tls/key.pem",),

--- a/app/imageswap/test/test_exact_mapping.py
+++ b/app/imageswap/test/test_exact_mapping.py
@@ -42,7 +42,7 @@ class ExactMapping(unittest.TestCase):
 
     def test_map_default(self):
 
-        """Method to test that default mapping is working"""
+        """Method to test that default mapping is working for config files with [EXACT] entries"""
 
         imageswap.imageswap_maps_file = "./testing/map_files/map_file_exact.conf"
 
@@ -58,7 +58,7 @@ class ExactMapping(unittest.TestCase):
 
     def test_map_host(self):
 
-        """Method to test that host based mapping is working"""
+        """Method to test that host based mapping is working for config files with [EXACT] entries"""
 
         imageswap.imageswap_maps_file = "./testing/map_files/map_file_exact.conf"
 
@@ -74,7 +74,7 @@ class ExactMapping(unittest.TestCase):
 
     def test_map_exact_helloworld(self):
 
-        """Method to test Map File config (default swap map has no value)"""
+        """Method to test exact mapping for entries without hostname, path and image tag"""
 
         imageswap.imageswap_maps_file = "./testing/map_files/map_file_exact.conf"
 
@@ -90,7 +90,7 @@ class ExactMapping(unittest.TestCase):
 
     def test_map_exact_ubuntu(self):
 
-        """Method to test Map File config (default swap map has no value)"""
+        """Method to test exact mapping for entries with hostname but without path and image tag"""
 
         imageswap.imageswap_maps_file = "./testing/map_files/map_file_exact.conf"
 
@@ -106,7 +106,7 @@ class ExactMapping(unittest.TestCase):
 
     def test_map_mysqlserver(self):
 
-        """Method to test Map File config (default swap map has no value)"""
+        """Method to test exact mapping for entries without hostname and image tag but with a path"""
 
         imageswap.imageswap_maps_file = "./testing/map_files/map_file_exact.conf"
 
@@ -122,7 +122,7 @@ class ExactMapping(unittest.TestCase):
 
     def test_map_mysqlserver56(self):
 
-        """Method to test Map File config (default swap map has no value)"""
+        """Method to test exact mapping for entries without hostname but with path and image tag"""
 
         imageswap.imageswap_maps_file = "./testing/map_files/map_file_exact.conf"
 
@@ -138,7 +138,7 @@ class ExactMapping(unittest.TestCase):
 
     def test_map_exact_nvcr(self):
 
-        """Method to test Map File config (default swap map has no value)"""
+        """Method to test exact mapping for entries with hostname and image tag (also a host based mapping exists for this host)"""
 
         imageswap.imageswap_maps_file = "./testing/map_files/map_file_exact.conf"
 

--- a/app/imageswap/test/test_exact_mapping.py
+++ b/app/imageswap/test/test_exact_mapping.py
@@ -40,7 +40,6 @@ class ExactMapping(unittest.TestCase):
 
         pass
 
-
     def test_map_default(self):
 
         """Method to test that default mapping is working"""
@@ -56,7 +55,6 @@ class ExactMapping(unittest.TestCase):
 
         self.assertTrue(result)
         self.assertEqual(container_spec["image"], expected_image)
-
 
     def test_map_host(self):
 
@@ -74,7 +72,6 @@ class ExactMapping(unittest.TestCase):
         self.assertTrue(result)
         self.assertEqual(container_spec["image"], expected_image)
 
-
     def test_map_exact_helloworld(self):
 
         """Method to test Map File config (default swap map has no value)"""
@@ -90,7 +87,6 @@ class ExactMapping(unittest.TestCase):
 
         self.assertTrue(result)
         self.assertEqual(container_spec["image"], expected_image)
-
 
     def test_map_exact_ubuntu(self):
 
@@ -108,7 +104,6 @@ class ExactMapping(unittest.TestCase):
         self.assertTrue(result)
         self.assertEqual(container_spec["image"], expected_image)
 
-
     def test_map_mysqlserver(self):
 
         """Method to test Map File config (default swap map has no value)"""
@@ -124,7 +119,6 @@ class ExactMapping(unittest.TestCase):
 
         self.assertTrue(result)
         self.assertEqual(container_spec["image"], expected_image)
-
 
     def test_map_mysqlserver56(self):
 
@@ -142,7 +136,6 @@ class ExactMapping(unittest.TestCase):
         self.assertTrue(result)
         self.assertEqual(container_spec["image"], expected_image)
 
-
     def test_map_exact_nvcr(self):
 
         """Method to test Map File config (default swap map has no value)"""
@@ -158,7 +151,6 @@ class ExactMapping(unittest.TestCase):
 
         self.assertTrue(result)
         self.assertEqual(container_spec["image"], expected_image)
-
 
 
 if __name__ == "__main__":

--- a/app/imageswap/test/test_exact_mapping.py
+++ b/app/imageswap/test/test_exact_mapping.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python
+
+# Copyright 2020 The WebRoot, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.append("./app/imageswap")
+import imageswap
+
+###########################################################################
+# Test image tag mapping scenarios ########################################
+###########################################################################
+
+
+@patch("imageswap.imageswap_mode", "MAPS")
+@patch("imageswap.imageswap_maps_file", "./testing/map_files/map_file.conf")
+class ExactMapping(unittest.TestCase):
+    def setUp(self):
+
+        self.app = imageswap.app.test_client()
+        self.app.testing = True
+        imageswap.app.logger.setLevel("DEBUG")
+
+    def tearDown(self):
+
+        pass
+
+
+    def test_map_default(self):
+
+        """Method to test that default mapping is working"""
+
+        imageswap.imageswap_maps_file = "./testing/map_files/map_file_exact.conf"
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "any-image"
+
+        expected_image = "default.example.com/any-image"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
+
+    def test_map_host(self):
+
+        """Method to test that host based mapping is working"""
+
+        imageswap.imageswap_maps_file = "./testing/map_files/map_file_exact.conf"
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "nvcr.io/any-image"
+
+        expected_image = "harbor.example.com/any-image"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
+
+    def test_map_exact_helloworld(self):
+
+        """Method to test Map File config (default swap map has no value)"""
+
+        imageswap.imageswap_maps_file = "./testing/map_files/map_file_exact.conf"
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "hello-world"
+
+        expected_image = "myownrepo.example.com/base/public-image-cache:hello-world"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
+
+    def test_map_exact_ubuntu(self):
+
+        """Method to test Map File config (default swap map has no value)"""
+
+        imageswap.imageswap_maps_file = "./testing/map_files/map_file_exact.conf"
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "ubutun:18.04"
+
+        expected_image = "myownrepo.example.com/base/public-image-cache:ubuntu_18.04"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
+
+    def test_map_mysqlserver(self):
+
+        """Method to test Map File config (default swap map has no value)"""
+
+        imageswap.imageswap_maps_file = "./testing/map_files/map_file_exact.conf"
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "mysql/mysql-server"
+
+        expected_image = "myownrepo.example.com/base/public-image-cache:mysql_mysql-server"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
+
+    def test_map_mysqlserver56(self):
+
+        """Method to test Map File config (default swap map has no value)"""
+
+        imageswap.imageswap_maps_file = "./testing/map_files/map_file_exact.conf"
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "mysql/mysql-server:5.6"
+
+        expected_image = "myownrepo.example.com/base/public-image-cache:mysql_mysql-server_5.6"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
+
+    def test_map_exact_nvcr(self):
+
+        """Method to test Map File config (default swap map has no value)"""
+
+        imageswap.imageswap_maps_file = "./testing/map_files/map_file_exact.conf"
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "nvcr.io/nvidia:k8s-device-plugin_v0.9.0"
+
+        expected_image = "myownrepo.example.com/base/private-image-cache:nvcr.io_nvidia_k8s-device-plugin_v0.9.0"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/testing/map_files/map_file_exact.conf
+++ b/testing/map_files/map_file_exact.conf
@@ -1,0 +1,10 @@
+# The contents of this file is linked to Python unittest assertions and should 
+# not be changed without consideration for updating the related tests.
+default:default.example.com
+nvcr.io:harbor.example.com
+
+[EXACT]hello-world::myownrepo.example.com/base/public-image-cache:hello-world
+[EXACT]ubutun:18.04::myownrepo.example.com/base/public-image-cache:ubuntu_18.04
+[EXACT]mysql/mysql-server::myownrepo.example.com/base/public-image-cache:mysql_mysql-server
+[EXACT]mysql/mysql-server:5.6::myownrepo.example.com/base/public-image-cache:mysql_mysql-server_5.6
+[EXACT]nvcr.io/nvidia:k8s-device-plugin_v0.9.0::myownrepo.example.com/base/private-image-cache:nvcr.io_nvidia_k8s-device-plugin_v0.9.0


### PR DESCRIPTION
Allow configuring mapping entries which are handled as "exact" mapping.
Before the normal mapping logic is applied, it is checked, whether for this image an exact mapping exists.
If so, then the value for this mapping is used as new-image.

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

See issue #51 

**Which issue(s) this PR fixes**:

Fixes #51 

**Special notes for your reviewer**:

This PR replaces the old PR #52 

**Does this PR introduce a user-facing change?**:

```release-note
The maps config syntax is extended. 
All lines with an "[EXACT]" prefix will be handled special. 
Besides these entries all previous configuration work as before.
```

**Additional documentation e.g., usage docs, etc.**:

```docs
The IMAGESWAP_MODE "MAPS" now supports exact mappings.
If a config line has an "[EXACT]" prefix, like this:

[EXACT]<original-image>::<target-image>

It will be handled in the following way:
If the docker image to swap is exactly the same as the configured <original-image> name 
the swapped docker image will be <target-image>. E.g.:

[EXACT]mysql/mysql-server:5.6::myownrepo.example.com/base/public-image-cache:mysql_mysql-server_5.6

This will map "mysql/mysql-server:5.6" to "myownrepo.example.com/base/public-image-cache:mysql_mysql-server_5.6"
_**No**_ normalization is done, like adding ":latest" image tag or "docker.io" host.
```