### PR TITLE
Bumped base images to python:3.8.12-alpine3.15

### DIFF
--- a/app/imageswap-init/Dockerfile
+++ b/app/imageswap-init/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.8.12-alpine3.15
 
 LABEL maintainer=joe@twr.io
 

--- a/app/imageswap/Dockerfile
+++ b/app/imageswap/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.8.12-alpine3.15
 
 LABEL maintainer=joe@twr.io
 


### PR DESCRIPTION
This removes python:3-alpine, generic but susceptible to which version is actually latest at build time. See details in #60 

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This fixes removes (as of 6/1/2022) most vulnerabilities found in v.1.4.2.

BEFORE FIXING BASE IMAGE TAG:
* [trivy-report-imageswap.txt](https://github.com/phenixblue/imageswap-webhook/files/7821444/trivy-report-imageswap.txt)
* [trivy-report-imageswap-init.txt](https://github.com/phenixblue/imageswap-webhook/files/7821445/trivy-report-imageswap-init.txt)

AFTER FIXING BASE IMAGE TAG:

* [trivy-report-imageswap-after-fix.txt](https://github.com/phenixblue/imageswap-webhook/files/7821501/trivy-report-imageswap-after-fix.txt) (derived via `docker build -t imageswap . && trivy image imageswap >trivy-report-imageswap-after-fix.txt` in directory `app/imageswap`)
* [trivy-report-imageswap-init-after-fix.txt](https://github.com/phenixblue/imageswap-webhook/files/7821514/trivy-report-imageswap-init-after-fix.txt) (derived via `docker build -t imageswap-init . && trivy image imageswap-init >trivy-report-imageswap-init-after-fix.txt` in directory `app/imageswap-init`)

**Which issue(s) this PR fixes**:

Fixes #60 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., usage docs, etc.**:


```docs

```
