### PR TITLE
Fixed a typo (clulster -> cluster)

### DIFF
--- a/deploy/install.yaml
+++ b/deploy/install.yaml
@@ -13,7 +13,7 @@ metadata:
   namespace: imageswap-system
   labels:
     app: imageswap
-    resource: clulsterrole
+    resource: clusterrole
 rules:
 - apiGroups:
   - admissionregistration.k8s.io
@@ -42,7 +42,7 @@ metadata:
   name: imageswap-read
   labels:
     app: imageswap
-    resource: clulsterrole
+    resource: clusterrole
 rules:
 - apiGroups:
   - ""

--- a/deploy/manifests/imageswap-cluster-rbac.yaml
+++ b/deploy/manifests/imageswap-cluster-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: imageswap-system
   labels:
     app: imageswap
-    resource: clulsterrole
+    resource: clusterrole
 rules:
 - apiGroups:
   - admissionregistration.k8s.io
@@ -34,7 +34,7 @@ metadata:
   name: imageswap-read
   labels:
     app: imageswap
-    resource: clulsterrole
+    resource: clusterrole
 rules:
 - apiGroups:
   - ""


### PR DESCRIPTION
Nothing more than a typo in manifests.

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
A user relying on selector "resource" might have issues due to unexpected values in the affected resources.

**Which issue(s) this PR fixes**:

I haven't opened an issue for this, being just a minor issue, but I can if you prefer

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., usage docs, etc.**:

```docs
NONE
```