### PR TITLE
Cleanup unneeded PKS logic & fix for #56

### DIFF
--- a/.github/workflows/ci-e2e-checks.yaml
+++ b/.github/workflows/ci-e2e-checks.yaml
@@ -15,19 +15,19 @@ jobs:
     strategy:
       matrix:
         k8s-version:
+          - v1.23
           - v1.22
           - v1.21
           - v1.20
-          - v1.19
         include:
+          - k8s-version: v1.23
+            kind-node-image: kindest/node:v1.23.4@sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9
           - k8s-version: v1.22
             kind-node-image: kindest/node:v1.22.7@sha256:1dfd72d193bf7da64765fd2f2898f78663b9ba366c2aa74be1fd7498a1873166
           - k8s-version: v1.21
             kind-node-image: kindest/node:v1.21.10@sha256:84709f09756ba4f863769bdcabe5edafc2ada72d3c8c44d6515fc581b66b029c
           - k8s-version: v1.20
             kind-node-image: kindest/node:v1.20.15@sha256:393bb9096c6c4d723bb17bceb0896407d7db581532d11ea2839c80b28e5d8deb
-          - k8s-version: v1.19
-            kind-node-image: kindest/node:v1.19.16@sha256:81f552397c1e6c1f293f967ecb1344d8857613fb978f963c30e907c32f598467
 
     name: e2e-tests for K8s ${{ matrix.k8s-version }}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/phenixblue/imageswap-webhook/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added and/or ran the appropriate tests for your PR
4. If the PR is unfinished, please mark it as "[WIP]"
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation

/kind feature
> /kind release

**What this PR does / why we need it**:

This cleans up pre-existing logic for handling PKS (Pivotal Kubernetes Service, aka. TKGi) where the K8s Root CA Cert was stored in a non-standard location.

Previously the Root CA Cert was read from either a PKS specific ConfigMap or from the in-cluster kubeconfig.

This change moves to reading the K8s Root CA cert from the now standardized `kube-root-ca.crt` ConfigMap that conformant k8s clusters will have in every namespace by default.

This simplifies the code for the init container and moves to a unified logic.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #56
Fixes #69 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required"
-->

```release-note
- Move to unified logic for detecting the k8s Root CA Cert for all conformant clusters
```

**Additional documentation e.g., usage docs, etc.**:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```