### PR TITLE
Read env to change the CSR signer name

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Kubernetes APIs upgrade
 
 >**K8s prior to v1.19** ImageSwap v1.5.0+ drops support for k8s versions below v1.19 and will no longer work due to the `admissionregistration.k8s.io/v1beta1` api deprecation. For deployment on K8s version v1.19 and before, please use ImageSwap v1.4.x.
 
->**EKS 1.22** To use ImageSwap you'll need to setup an Amazon exclusive signer [`beta.eks.amazonaws.com/app-serving`](https://docs.aws.amazon.com/eks/latest/userguide/cert-signing.html). Look at `client.V1CertificateSigningRequestSpec()` on `app/imageswap-init/imageswap-init.py`.
+>**EKS 1.22** To use ImageSwap you'll need to setup an Amazon exclusive signer [`beta.eks.amazonaws.com/app-serving`](https://docs.aws.amazon.com/eks/latest/userguide/cert-signing.html). This value can be changed with the environmental variable `IMAGESWAP_CSR_SIGNER_NAME`. Look at `client.V1CertificateSigningRequestSpec()` on `app/imageswap-init/imageswap-init.py`.
 ```
 k8s_csr_spec = client.V1CertificateSigningRequestSpec(
         groups=["system:authenticated"],

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Kubernetes APIs upgrade
 
 >**K8s prior to v1.19** ImageSwap v1.5.0+ drops support for k8s versions below v1.19 and will no longer work due to the `admissionregistration.k8s.io/v1beta1` api deprecation. For deployment on K8s version v1.19 and before, please use ImageSwap v1.4.x.
 
->**EKS 1.22** To use ImageSwap you'll need to setup an Amazon exclusive signer [`beta.eks.amazonaws.com/app-serving`](https://docs.aws.amazon.com/eks/latest/userguide/cert-signing.html). This value can be changed with the environmental variable `IMAGESWAP_CSR_SIGNER_NAME`. Look at `client.V1CertificateSigningRequestSpec()` on `app/imageswap-init/imageswap-init.py`.
+>**EKS 1.22** To use ImageSwap you'll need to setup an Amazon exclusive signer [`beta.eks.amazonaws.com/app-serving`](https://docs.aws.amazon.com/eks/latest/userguide/cert-signing.html). Look at `client.V1CertificateSigningRequestSpec()` on `app/imageswap-init/imageswap-init.py`.
 ```
 k8s_csr_spec = client.V1CertificateSigningRequestSpec(
         groups=["system:authenticated"],

--- a/app/imageswap-init/imageswap-init.py
+++ b/app/imageswap-init/imageswap-init.py
@@ -51,6 +51,7 @@ imageswap_mwc_name = "imageswap-webhook"
 imageswap_mwc_template_file = f"{imageswap_mwc_template_path}/imageswap-mwc.yaml"
 imageswap_mwc_webhook_name = "imageswap.webhook.k8s.twr.io"
 imageswap_tls_byoc = False
+imageswap_csr_signer_name = os.getenv("IMAGESWAP_CSR_SIGNER_NAME", "kubernetes.io/kubelet-serving")
 
 ################################################################################
 ################################################################################
@@ -156,7 +157,7 @@ def build_k8s_csr(namespace, service_name, key):
         groups=["system:authenticated"],
         usages=["key encipherment", "digital signature", "server auth"],
         request=base64.b64encode(csr_pem).decode("utf-8").rstrip(),
-        signer_name="kubernetes.io/kubelet-serving",
+        signer_name=imageswap_csr_signer_name,
     )
 
     k8s_csr = client.V1CertificateSigningRequest(

--- a/docs/advanced_install.md
+++ b/docs/advanced_install.md
@@ -6,13 +6,14 @@ We've tried to build a decent amount of flexibility into ImageSwap. While the si
 
 NOTE: The following environment variable are defined in the `imageswap-env-cm.yaml` manifest and can be used to customize ImageSwap's behavior.
 
-| Variable                 | Description                                 | Values                        |
-|---                       |---                                          |---                            |
-| `IMAGESWAP_LOG_LEVEL`    | The log level to use                        | `INFO` or `DEBUG`             |
+| Variable                    | Description                                 | Values                        |
+|---                          |---                                          |---                            |
+| `IMAGESWAP_LOG_LEVEL`       | The log level to use                        | `INFO` or `DEBUG`             |
 | `IMAGE_PREFIX` (**DEPRECATED**)          | The prefix to use in the image swap         | Any value supported for the [Kubernetes Container spec image field](https://kubernetes.io/docs/concepts/containers/images/#image-names)      |
-| `IMAGESWAP_MODE`         | The operating mode for the swap logic       | `MAPS` (default in v1.4.0+) or `LEGACY`              |
-| `IMAGESWAP_MAPS_FILE`    | The location of the MAPS file               | `/app/maps/imageswap-maps.conf` (default)            |
-| `IMAGESWAP_DISABLE_LABEL`| The label to identify granular disablement of image swapping per resource | `k8s.twr.io/imageswap` |
+| `IMAGESWAP_MODE`            | The operating mode for the swap logic       | `MAPS` (default in v1.4.0+) or `LEGACY`              |
+| `IMAGESWAP_MAPS_FILE`       | The location of the MAPS file               | `/app/maps/imageswap-maps.conf` (default)            |
+| `IMAGESWAP_DISABLE_LABEL`   | The label to identify granular disablement of image swapping per resource | `k8s.twr.io/imageswap` |
+| `IMAGESWAP_CSR_SIGNER_NAME` | The name of the Kubernetes signer to create the API certificate | `kubernetes.io/kubelet-serving`  |
 
 ## Installation
 
@@ -64,7 +65,7 @@ $ kubectl create secret generic imageswap-tls-ca --from-file=rootca.pem=./path/t
 
 The MWC (Mutating Webhook Configuration) needs to be configured with a cert bundle that includes the CA that signed the certificate and key used to secure the ImageSwap API. For now ImageSwap assumes this CA certificate exists in the `imageswap-tls-ca` secret deployed within the `imageswap-system` namespace. This secret must exist prior to installing ImageSwap.
 
-No validation is done currently to ensure the specified CA actually signed the cert and key used to secure ImageSwap's API. 
+No validation is done currently to ensure the specified CA actually signed the cert and key used to secure ImageSwap's API.
 
 ## MWC Template
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/phenixblue/imageswap-webhook/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added and/or ran the appropriate tests for your PR
4. If the PR is unfinished, please mark it as "[WIP]"
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
As stated on the README, on EKS 1.22 it's needed to use the certificate signer `beta.eks.amazonaws.com/app-serving`.

The issue is that with the current code, the only way to do it is changing it, creating a new and custom docker image, and use it with the new signer.

This PR adds a new environmental variable that allows to define this signer to the one the user wants, with the default value that it's currently being used (`kubernetes.io/kubelet-serving`), so no breaking changes are introduced.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required"
-->

```release-note
New env `IMAGESWAP_CSR_SIGNER_NAME` added, allowing to define what signer to use on the Certificate Signing Request.
```

**Additional documentation e.g., usage docs, etc.**:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs
On the current deploy files, a new element should be added to the 'imageswap-env' configmap, resulting in:

kind: ConfigMap
apiVersion: v1
metadata:
  name: imageswap-env
  namespace: imageswap-system
  labels:
    app: imageswap
    resource: configmap
data:
  FLASK_ENV: "production"
  PYTHONUNBUFFERED: "TRUE"
  IMAGESWAP_MODE: "MAPS"
  IMAGESWAP_LOG_LEVEL: "INFO"
  IMAGESWAP_CSR_SIGNER_NAME: "beta.eks.amazonaws.com/app-serving"
```