### PR TITLE
Update mapfile separator :: (new syntax)

### DIFF
--- a/deploy/install.yaml
+++ b/deploy/install.yaml
@@ -208,7 +208,7 @@ metadata:
 apiVersion: v1
 data:
   maps: |
-    default:registry.example.com
+    default::registry.example.com
 kind: ConfigMap
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
In Mapfile, the syntax : is deprecated as of v1.4.3 and will be removed in future versions. Map file configurations should use the new syntax ie. ::
