### PR TITLE
Prepare v1.5.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,3 +156,25 @@ This is primarily a maintenance release with a couple of small enhancements.
 - Thanks to @jchanam for their work on #76
 - Thanks to @howardburgess for suggesting #67
 - Thanks to @rainsun for bringing #56 to our attention and supplying logs to help triage the issue
+
+## 1.5.2
+
+This is primarily a maintenance release, but does introduce new MAPS syntax.
+
+The `replace` feature gives the ability to match a pattern explicitly and replace all of it with a provided pattern. [More info here](https://github.com/phenixblue/imageswap-webhook#replace-image-mapping).
+
+### Enhancements
+
+- Bump oauthlib from 3.2.0 to 3.2.1 in /app/imageswap-init (#79)
+- Add `replace` feature to maps syntax (#85)
+- Bump certifi from 2022.9.14 to 2022.12.7 in /app/imageswap-init (#91)
+- Move to `actions/setup-python@v4` in CI (#91)
+- Fix detection of `IMAGESWAP_DISABLE_AUTO_MWC` (#88)
+- Bump cryptography from 38.0.4 to 39.0.1 in /app/imageswap-init (#92)
+- Bump werkzeug from 2.2.2 to 2.2.3 in /app/imageswap (#93)
+
+### Acknowledgements
+
+- Thanks to @dependabot for keeping our Dependencies up to date!
+- Thanks to @M4C4R for #85
+- Thanks to @howardburgess for #88

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@
 # NOTE: The version for both `imageswap-init` and `imageswap` should be identical for now.
 # Some effort will need to be put in to be able to distringuish changes to one vs. the other
 # in CI/Release steps.
-IMAGESWAP_VERSION := v1.5.1
-IMAGESWAP_INIT_VERSION := v1.5.1
+IMAGESWAP_VERSION := v1.5.2
+IMAGESWAP_INIT_VERSION := v1.5.2
 
 REPO_ROOT := $(CURDIR)
 APP_NAME ?= "imageswap.py"

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ You can use the following command to install ImageSwap from this repo with sane 
 **NOTE:** The quickstart installation is not meant for production use. Please read through the [Cautions](#cautions) sections, and as always, use your best judgement when configuring ImageSwap for production scenarios.
 
 ```shell
-$ kubectl apply -f https://raw.githubusercontent.com/phenixblue/imageswap-webhook/v1.5.1/deploy/install.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/phenixblue/imageswap-webhook/v1.5.2/deploy/install.yaml
 ```
 
 #### This will do the following

--- a/app/imageswap/imageswap.py
+++ b/app/imageswap/imageswap.py
@@ -426,7 +426,7 @@ def swap_image(container_spec):
 
 def main():
 
-    app.logger.info("ImageSwap v1.5.1 Startup")
+    app.logger.info("ImageSwap v1.5.2 Startup")
 
     app.run(
         host="0.0.0.0",

--- a/deploy/install.yaml
+++ b/deploy/install.yaml
@@ -275,7 +275,7 @@ spec:
         runAsGroup: 1898
       initContainers:
         - name: imageswap-init
-          image: thewebroot/imageswap-init:v1.5.1
+          image: thewebroot/imageswap-init:v1.5.2
           command: [/app/imageswap-init.py]
           imagePullPolicy: Always
           securityContext:
@@ -299,7 +299,7 @@ spec:
               mountPath: /mwc
       containers:
       - name: imageswap
-        image: thewebroot/imageswap:v1.5.1
+        image: thewebroot/imageswap:v1.5.2
         ports:
         - containerPort: 5000
         command: ["gunicorn", "imageswap:app", "--config=config.py"]

--- a/deploy/manifests/imageswap-deploy.yaml
+++ b/deploy/manifests/imageswap-deploy.yaml
@@ -22,7 +22,7 @@ spec:
         runAsGroup: 1898
       initContainers:
         - name: imageswap-init
-          image: thewebroot/imageswap-init:v1.5.1
+          image: thewebroot/imageswap-init:v1.5.2
           command: [/app/imageswap-init.py]
           imagePullPolicy: Always
           securityContext:
@@ -46,7 +46,7 @@ spec:
               mountPath: /mwc
       containers:
       - name: imageswap
-        image: thewebroot/imageswap:v1.5.1
+        image: thewebroot/imageswap:v1.5.2
         ports:
         - containerPort: 5000
         command: ["gunicorn", "imageswap:app", "--config=config.py"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/phenixblue/imageswap-webhook/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added and/or ran the appropriate tests for your PR
4. If the PR is unfinished, please mark it as "[WIP]"
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind feature

/kind release

**What this PR does / why we need it**:

This prepares the v1.5.2 release of the ImageSwap Webhook

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #94 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required"
-->

```release-note
This is primarily a maintenance release, but does introduce new MAPS syntax.

The `replace` feature gives the ability to match a pattern explicitly and replace all of it with a provided pattern. [More info here](https://github.com/phenixblue/imageswap-webhook#replace-image-mapping).

### Enhancements

- Bump oauthlib from 3.2.0 to 3.2.1 in /app/imageswap-init (#79)
- Add `replace` feature to maps syntax (#85)
- Bump certifi from 2022.9.14 to 2022.12.7 in /app/imageswap-init (#91)
- Move to `actions/setup-python@v4` in CI (#91)
- Fix detection of `IMAGESWAP_DISABLE_AUTO_MWC` (#88)
- Bump cryptography from 38.0.4 to 39.0.1 in /app/imageswap-init (#92)
- Bump werkzeug from 2.2.2 to 2.2.3 in /app/imageswap (#93)

### Acknowledgements

- Thanks to @dependabot for keeping our Dependencies up to date!
- Thanks to @M4C4R for #85
- Thanks to @howardburgess for #88

```

**Additional documentation e.g., usage docs, etc.**:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```