### PR TITLE
BUGFIX: identity mapping with EXACT and REPLACE is ignored

### DIFF
--- a/app/imageswap/imageswap.py
+++ b/app/imageswap/imageswap.py
@@ -296,18 +296,21 @@ def swap_image(container_spec):
         app.logger.debug(f"Exact Maps:\n{exact_maps}")
         app.logger.debug(f"Replace Maps:\n{replace_maps}")
 
+        found = False
         if image in exact_maps:
             app.logger.debug("found exact mapping")
             new_image = exact_maps[image]
+            found = True
         else:
             # Check to see if a replacement pattern matches
             for pattern in replace_maps.keys():
                 if fnmatch.fnmatch(image, pattern):
                     new_image = os.path.join(replace_maps[pattern], image.split("/")[-1])
+                    found = True
                     break
 
-        # Fallback to standard checks if the image has not been changed
-        if new_image == image:
+        # Fallback to standard checks if the image has not been found
+        if not found:
             # Check if Registry portion includes a ":<port_number>"
             if ":" in image_registry:
                 image_registry_noport = image_registry.partition(":")[0]

--- a/app/imageswap/test/test_exact_mapping.py
+++ b/app/imageswap/test/test_exact_mapping.py
@@ -152,6 +152,22 @@ class ExactMapping(unittest.TestCase):
         self.assertTrue(result)
         self.assertEqual(container_spec["image"], expected_image)
 
+    def test_map_exact_unchanged(self):
+
+        """Method to test exact mapping for entries which should not be changed, like [EXACT]auto::auto"""
+
+        imageswap.imageswap_maps_file = "./testing/map_files/map_file_exact.conf"
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "auto"
+
+        expected_image = "auto"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/app/imageswap/test/test_replace_mapping.py
+++ b/app/imageswap/test/test_replace_mapping.py
@@ -167,6 +167,22 @@ class ReplaceMapping(unittest.TestCase):
         self.assertTrue(result)
         self.assertEqual(container_spec["image"], expected_image)
 
+    def test_map_replace_unchanged(self):
+
+        """Method to test replace when the result has not changed from the original"""
+
+        imageswap.imageswap_maps_file = "./testing/map_files/map_file_replace.conf"
+
+        container_spec = {}
+        container_spec["name"] = "test-container"
+        container_spec["image"] = "auto"
+
+        expected_image = "auto"
+        result = imageswap.swap_image(container_spec)
+
+        self.assertTrue(result)
+        self.assertEqual(container_spec["image"], expected_image)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/testing/map_files/map_file_exact.conf
+++ b/testing/map_files/map_file_exact.conf
@@ -8,3 +8,4 @@ nvcr.io:harbor.example.com
 [EXACT]mysql/mysql-server::myownrepo.example.com/base/public-image-cache:mysql_mysql-server
 [EXACT]mysql/mysql-server:5.6::myownrepo.example.com/base/public-image-cache:mysql_mysql-server_5.6
 [EXACT]nvcr.io/nvidia:k8s-device-plugin_v0.9.0::myownrepo.example.com/base/private-image-cache:nvcr.io_nvidia_k8s-device-plugin_v0.9.0
+[EXACT]auto::auto

--- a/testing/map_files/map_file_replace.conf
+++ b/testing/map_files/map_file_replace.conf
@@ -9,3 +9,4 @@ nvcr.io:harbor.example.com
 [REPLACE]*mysql-server:5.6::myownrepo.example.com/base/public-image-cache
 [REPLACE]*nvidia:k8s-device-plugin_*::myownrepo.example.com/base/
 [REPLACE]hello:v1.?::myownrepo.example.com/base/public-image-cache
+[REPLACE]auto::


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/phenixblue/imageswap-webhook/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added and/or ran the appropriate tests for your PR
4. If the PR is unfinished, please mark it as "[WIP]"
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
/kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind feature
> /kind release

**What this PR does / why we need it**:

I had problems with Istio, because it creates an ingress POD which has a dummy image with name "auto" (see [here](https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#customizing-injection) ). 
Imageswap interpreted this as "docker.io/auto" and replaced it according to my rules with "dockermirror.example.com/auto". 
This caused problems.
To avoid this I added the following rule to the mappings:

```
[EXACT]auto::auto
```

This should fix the problem, but it does not. 
In the logfile I can see, that the exact mapping was found, but nevertheless furter mappings like (docker.io->dockermirror.example.com) were applied.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

did not create an issue for this PR

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required"
-->

```release-note
NONE
```

**Additional documentation e.g., usage docs, etc.**:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```