### PR TITLE
fix: 🐛 Add special case were registry is defined for library image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@
 # NOTE: The version for both `imageswap-init` and `imageswap` should be identical for now.
 # Some effort will need to be put in to be able to distringuish changes to one vs. the other
 # in CI/Release steps.
-IMAGESWAP_VERSION := v1.5.3
-IMAGESWAP_INIT_VERSION := v1.5.3
+IMAGESWAP_VERSION := v1.5.4
+IMAGESWAP_INIT_VERSION := v1.5.4
 
 REPO_ROOT := $(CURDIR)
 APP_NAME ?= "imageswap.py"

--- a/app/imageswap/imageswap.py
+++ b/app/imageswap/imageswap.py
@@ -274,6 +274,12 @@ def swap_image(container_spec):
     no_registry = False
     library_image = False
 
+    # special case when the image is a library image but also has docker.io
+    # example: 'docker.io/alpine:latest'
+    if image_split[0] == "docker.io" and "/" not in image_split[2]:
+        image = image.replace("docker.io/", "")
+        image_split = image.partition("/")
+
     # Check if first section is a Registry URL
     if "." in image_split[0] and image_split[1] != "" and image_split[2] != "":
         image_registry = image_split[0]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/phenixblue/imageswap-webhook/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request.
3. Ensure you have added and/or ran the appropriate tests for your PR
4. If the PR is unfinished, please mark it as "[WIP]"
-->

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

This handles a special case when a library image is defined while still having docker.io domain defined.

Example: docker.io/bash:latest

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #119

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required"
-->

```release-note
- handle docker library images correctly when domain is defined
```

**Additional documentation e.g., usage docs, etc.**:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```